### PR TITLE
Model level features as the set of feature blocks

### DIFF
--- a/src/progression/ClassProgression.ts
+++ b/src/progression/ClassProgression.ts
@@ -50,7 +50,11 @@ export class ClassProgression<R extends ItemReference> {
   /**
    * Try to find a feature within the specified level
    */
-  findFeature(levelId: string, featureSetId: string, featureId: string): R | null {
+  findFeature(
+    levelId: string,
+    featureSetId: string,
+    featureId: string
+  ): R | null {
     return this.levels
       .find((l) => l.id === levelId)
       ?.features.findFeature(featureSetId, featureId);
@@ -282,7 +286,7 @@ export class LevelFeatures<R extends ItemReference> {
    * Try to find the feature by its id
    */
   findFeature(featureSetId: string, id: string): R | null {
-    return this.findFeatureIn(this.featureSets[featureSetId], id)
+    return this.findFeatureIn(this.featureSets[featureSetId], id);
   }
 
   addGranted(featureSetId: string, reference: R): LevelFeatures<R> {

--- a/src/progression/ClassProgression.ts
+++ b/src/progression/ClassProgression.ts
@@ -50,10 +50,10 @@ export class ClassProgression<R extends ItemReference> {
   /**
    * Try to find a feature within the specified level
    */
-  findFeature(levelId: string, featureId: string): R | null {
+  findFeature(levelId: string, featureSetId: string, featureId: string): R | null {
     return this.levels
       .find((l) => l.id === levelId)
-      ?.features.findFeature(featureId);
+      ?.features.findFeature(featureSetId, featureId);
   }
 
   /**
@@ -62,6 +62,7 @@ export class ClassProgression<R extends ItemReference> {
   public addFeature(
     featureType: FeatureType,
     levelId: string,
+    featureSetId: string,
     itemRef: R
   ): ClassProgression<R> {
     switch (featureType) {
@@ -69,7 +70,7 @@ export class ClassProgression<R extends ItemReference> {
         return this.withLevels(
           this.levels.map((l) => {
             if (l.id === levelId) {
-              return l.addGranted(itemRef);
+              return l.addGranted(featureSetId, itemRef);
             } else {
               return l;
             }
@@ -79,7 +80,7 @@ export class ClassProgression<R extends ItemReference> {
         return this.withLevels(
           this.levels.map((l) => {
             if (l.id === levelId) {
-              return l.addOption(itemRef);
+              return l.addOption(featureSetId, itemRef);
             } else {
               return l;
             }
@@ -89,7 +90,7 @@ export class ClassProgression<R extends ItemReference> {
         return this.withLevels(
           this.levels.map((l) => {
             if (l.id === levelId) {
-              return l.addPrerequisite(itemRef);
+              return l.addPrerequisite(featureSetId, itemRef);
             } else {
               return l;
             }
@@ -98,11 +99,15 @@ export class ClassProgression<R extends ItemReference> {
     }
   }
 
-  public removeFeature(levelId: string, itemId: string): ClassProgression<R> {
+  public removeFeature(
+    levelId: string,
+    featureSetId: string,
+    itemId: string
+  ): ClassProgression<R> {
     return this.withLevels(
       this.levels.map((l) => {
         if (l.id === levelId) {
-          return l.removeFeature(itemId);
+          return l.removeFeature(featureSetId, itemId);
         } else {
           return l;
         }
@@ -115,7 +120,7 @@ export class ClassProgression<R extends ItemReference> {
    */
   public addLevel(): ClassProgression<R> {
     const lvl = new ClassLevel(
-      this.randomString(),
+      randomString(),
       this.levels.length + 1,
       new LevelFeatures<R>()
     );
@@ -159,10 +164,6 @@ export class ClassProgression<R extends ItemReference> {
         return this as ClassProgression<IdRef>;
     }
   }
-
-  private randomString(): string {
-    return Math.random().toString(36).substr(2, 5);
-  }
 }
 
 export class ClassLevel<R extends ItemReference> {
@@ -193,46 +194,43 @@ export class ClassLevel<R extends ItemReference> {
     return new ClassLevel(this.id, this.level, this.features.refFeatures());
   }
 
-  addGranted(reference: R): ClassLevel<R> {
+  addGranted(featureSetId: string, reference: R): ClassLevel<R> {
     return new ClassLevel(
       this.id,
       this.level,
-      this.features.addGranted(reference)
+      this.features.addGranted(featureSetId, reference)
     );
   }
 
-  addOption(reference: R): ClassLevel<R> {
+  addOption(featureSetId: string, reference: R): ClassLevel<R> {
     return new ClassLevel(
       this.id,
       this.level,
-      this.features.addOption(reference)
+      this.features.addOption(featureSetId, reference)
     );
   }
 
-  addPrerequisite(reference: R): ClassLevel<R> {
+  addPrerequisite(featureSetId: string, reference: R): ClassLevel<R> {
     return new ClassLevel(
       this.id,
       this.level,
-      this.features.addPrerequisite(reference)
+      this.features.addPrerequisite(featureSetId, reference)
     );
   }
 
-  removeFeature(itemId: string): ClassLevel<R> {
+  removeFeature(featureSetId: string, itemId: string): ClassLevel<R> {
     return new ClassLevel(
       this.id,
       this.level,
-      this.features.removeFeature(itemId)
+      this.features.removeFeature(featureSetId, itemId)
     );
   }
 }
 
 export class LevelFeatures<R extends ItemReference> {
   constructor(
-    readonly granted: Items<R> = { items: [] },
-    readonly options: Items<R> = { items: [] },
-    readonly prerequisites: Items<R> & Prerequisites<R> = {
-      items: [],
-      prerequisites: [],
+    readonly featureSets: FeatureSets<R> = {
+      [randomString()]: emptyFeatureSet(),
     }
   ) {}
 
@@ -243,90 +241,114 @@ export class LevelFeatures<R extends ItemReference> {
   async derefFeatures(
     compendiumRepository: CompendiumRepository
   ): Promise<LevelFeatures<ItemRef>> {
-    return new LevelFeatures(
-      {
-        items: await this.derefItems(compendiumRepository, this.granted.items),
-      },
-      {
-        items: await this.derefItems(compendiumRepository, this.options.items),
-      },
-      {
-        items: await this.derefItems(
-          compendiumRepository,
-          this.prerequisites.items
-        ),
-      }
+    const derefed = await Promise.all(
+      Object.entries(this.featureSets).map<
+        Promise<[string, FeatureSet<ItemRef>]>
+      >(async ([key, value]) => {
+        const featureSet: FeatureSet<ItemRef> = {
+          granted: await this.derefItems(compendiumRepository, value.granted),
+          options: await this.derefItems(compendiumRepository, value.options),
+          prerequisites: await this.derefItems(
+            compendiumRepository,
+            value.prerequisites
+          ),
+        };
+        return [key, featureSet];
+      })
     );
+    return new LevelFeatures(Object.fromEntries(derefed));
   }
 
   /**
    * Return copy of this object with all the internal items referenced
    */
   refFeatures(): LevelFeatures<IdRef> {
-    return new LevelFeatures(
-      {
-        items: this.refItems(this.granted.items),
-      },
-      {
-        items: this.refItems(this.options.items),
-      },
-      {
-        items: this.refItems(this.prerequisites.items),
-      }
-    );
+    const refs = Object.entries(this.featureSets).map<
+      [string, FeatureSet<IdRef>]
+    >(([key, value]) => {
+      return [
+        key,
+        {
+          granted: this.refItems(value.granted),
+          options: this.refItems(value.options),
+          prerequisites: this.refItems(value.prerequisites),
+        },
+      ];
+    });
+    return new LevelFeatures(Object.fromEntries(refs));
   }
 
   /**
    * Try to find the feature by its id
    */
-  findFeature(id: string): R | null {
-    return (
-      this.granted.items.find((ref) => ref.id === id) ||
-      this.options.items.find((ref) => ref.id === id) ||
-      this.prerequisites.items.find((ref) => ref.id === id)
-    );
+  findFeature(featureSetId: string, id: string): R | null {
+    return this.findFeatureIn(this.featureSets[featureSetId], id)
   }
 
-  addGranted(reference: R): LevelFeatures<R> {
-    if (this.findFeature(reference.id)) return this;
-    return new LevelFeatures(
-      {
-        items: [...this.granted.items, reference],
+  addGranted(featureSetId: string, reference: R): LevelFeatures<R> {
+    if (this.findFeatureIn(this.featureSets[featureSetId], reference.id))
+      return this;
+    return new LevelFeatures({
+      ...this.featureSets,
+      [featureSetId]: {
+        ...this.featureSets[featureSetId],
+        granted: [...this.featureSets[featureSetId].granted, reference],
       },
-      this.options,
-      this.prerequisites
-    );
-  }
-
-  addOption(reference: R): LevelFeatures<R> {
-    return new LevelFeatures(
-      this.granted,
-      {
-        items: [...this.options.items, reference],
-      },
-      this.prerequisites
-    );
-  }
-
-  addPrerequisite(reference: R): LevelFeatures<R> {
-    return new LevelFeatures(this.granted, this.options, {
-      items: [...this.prerequisites.items, reference],
     });
   }
 
-  removeFeature(itemId: string): LevelFeatures<R> {
-    return new LevelFeatures(
-      {
-        items: this.granted.items.filter((feature) => feature.id !== itemId),
+  addOption(featureSetId: string, reference: R): LevelFeatures<R> {
+    if (this.findFeatureIn(this.featureSets[featureSetId], reference.id))
+      return this;
+    return new LevelFeatures({
+      ...this.featureSets,
+      [featureSetId]: {
+        ...this.featureSets[featureSetId],
+        options: [...this.featureSets[featureSetId].options, reference],
       },
-      {
-        items: this.options.items.filter((feature) => feature.id !== itemId),
+    });
+  }
+
+  addPrerequisite(featureSetId: string, reference: R): LevelFeatures<R> {
+    if (this.findFeatureIn(this.featureSets[featureSetId], reference.id))
+      return this;
+    return new LevelFeatures({
+      ...this.featureSets,
+      [featureSetId]: {
+        ...this.featureSets[featureSetId],
+        prerequisites: [
+          ...this.featureSets[featureSetId].prerequisites,
+          reference,
+        ],
       },
-      {
-        items: this.prerequisites.items.filter(
+    });
+  }
+
+  removeFeature(featureSetId: string, itemId: string): LevelFeatures<R> {
+    return new LevelFeatures({
+      ...this.featureSets,
+      [featureSetId]: {
+        granted: this.featureSets[featureSetId].granted.filter(
           (feature) => feature.id !== itemId
         ),
-      }
+        options: this.featureSets[featureSetId].options.filter(
+          (feature) => feature.id !== itemId
+        ),
+        prerequisites: this.featureSets[featureSetId].prerequisites.filter(
+          (feature) => feature.id !== itemId
+        ),
+      },
+    });
+  }
+
+  private findFeatureIn(
+    featureSet: FeatureSet<R>,
+    featureId: string
+  ): R | null {
+    return (
+      featureSet.granted.find((ref) => ref.id === featureId) ||
+      featureSet.options.find((ref) => ref.id === featureId) ||
+      featureSet.prerequisites.find((ref) => ref.id === featureId)
     );
   }
 
@@ -391,13 +413,25 @@ export type IdRef = {
 
 export type ItemReference = ItemRef | IdRef;
 
-type Items<R extends ItemReference> = {
-  items: Array<R>;
+type FeatureSets<R extends ItemReference> = Record<string, FeatureSet<R>>;
+
+type FeatureSet<R extends ItemReference> = {
+  prerequisites: Array<R>;
+  granted: Array<R>;
+  options: Array<R>;
 };
 
-type Prerequisites<R extends ItemReference> = {
-  prerequisites?: Array<R>;
-};
+function emptyFeatureSet<R extends ItemReference>(): FeatureSet<R> {
+  return {
+    prerequisites: [],
+    granted: [],
+    options: [],
+  };
+}
+
+function randomString(): string {
+  return Math.random().toString(36).substr(2, 5);
+}
 
 type RegularFeature = "granted";
 type OptionalFeature = "option";

--- a/src/progression/ProgressionForm.ts
+++ b/src/progression/ProgressionForm.ts
@@ -85,10 +85,11 @@ export class ProgressionForm {
           element.addEventListener("click", (_) => {
             const classId = element.getAttribute("data-class-id");
             const levelId = element.getAttribute("data-level-id");
+            const featureSetId = element.getAttribute("data-feature-set-id");
             const itemId = element.getAttribute("data-item-id");
 
             void progressionRepository
-              .findFeatureOf(classId, levelId, itemId)
+              .findFeatureOf(classId, levelId, featureSetId, itemId)
               .then((ref) => {
                 ref.item.sheet.render(true);
               });
@@ -102,9 +103,10 @@ export class ProgressionForm {
             event.preventDefault();
             const classId = element.getAttribute("data-class-id");
             const levelId = element.getAttribute("data-level-id");
+            const featureSetId = element.getAttribute("data-feature-set-id");
             const itemId = element.getAttribute("data-item-id");
             void progressionRepository
-              .removeFeatureOf(classId, levelId, itemId)
+              .removeFeatureOf(classId, levelId, featureSetId, itemId)
               .then((_) => this.render());
           });
         });
@@ -196,6 +198,7 @@ export class ProgressionForm {
               featureType: "granted",
               levelId: target.getAttribute("data-level-id"),
               classId: target.getAttribute("data-class-id"),
+              featureSetId: target.getAttribute("data-feature-set-id"),
             };
           } else if (
             target.classList.contains("features") &&
@@ -206,6 +209,7 @@ export class ProgressionForm {
               featureType: "option",
               levelId: target.getAttribute("data-level-id"),
               classId: target.getAttribute("data-class-id"),
+              featureSetId: target.getAttribute("data-feature-set-id"),
             };
           } else if (
             target.classList.contains("features") &&
@@ -216,6 +220,7 @@ export class ProgressionForm {
               featureType: "prerequisite",
               levelId: target.getAttribute("data-level-id"),
               classId: target.getAttribute("data-class-id"),
+              featureSetId: target.getAttribute("data-feature-set-id"),
             };
           }
         } else {
@@ -248,7 +253,8 @@ export class ProgressionForm {
             compendiumItem,
             dropTarget.featureType,
             dropTarget.classId,
-            dropTarget.levelId
+            dropTarget.levelId,
+            dropTarget.featureSetId
           );
         }
       }
@@ -270,12 +276,14 @@ export class ProgressionForm {
         featureItem: Item,
         featureType: FeatureType,
         classId: string,
-        levelId: string
+        levelId: string,
+        featureSetId: string
       ): Promise<ClassProgression<IdRef>[]> {
         return progressionRepository.addFeatureFor(
           classId,
           levelId,
           featureType,
+          featureSetId,
           featureItem
         );
       }
@@ -342,6 +350,7 @@ type LevelTarget = {
   featureType: FeatureType;
   levelId: string;
   classId: string;
+  featureSetId: string;
 };
 
 type ClassTarget = {

--- a/src/progression/ProgressionRepository.ts
+++ b/src/progression/ProgressionRepository.ts
@@ -190,7 +190,7 @@ export class FoundryProgressionRepository implements ProgressionRepository {
       progs.progs.map((p) => {
         //foundry stores plain JSON in settings, and therefore
         const lvls = p.levels.map((l) => {
-          const featureSets = l.features.featureSets
+          const featureSets = l.features.featureSets;
           const features = new LevelFeatures(featureSets);
           return new ClassLevel(l.id, l.level, features);
         });

--- a/src/progression/ProgressionRepository.ts
+++ b/src/progression/ProgressionRepository.ts
@@ -45,12 +45,14 @@ export interface ProgressionRepository {
     classId: string,
     levelId: string,
     featureType: FeatureType,
+    featureSetId: string,
     featureItem: Item
   ): Promise<ClassProgression<IdRef>[]>;
 
   removeFeatureOf(
     classId: string,
     levelId: string,
+    featureSetId: string,
     itemId: string
   ): Promise<ClassProgression<IdRef>[]>;
 
@@ -63,6 +65,7 @@ export interface ProgressionRepository {
   findFeatureOf(
     classId: string,
     levelId: string,
+    featureSetId: string,
     featureId: string
   ): Promise<ItemRef | null>;
 }
@@ -95,6 +98,7 @@ export class FoundryProgressionRepository implements ProgressionRepository {
     classId: string,
     levelId: string,
     featureType: FeatureType,
+    featureSetId: string,
     featureItem: Item
   ): Promise<ClassProgression<IdRef>[]> {
     const progs = await this.readProgression();
@@ -102,7 +106,7 @@ export class FoundryProgressionRepository implements ProgressionRepository {
     return this.writeProgression(
       progs.map((prog) => {
         if (prog.class.id === classId) {
-          return prog.addFeature(featureType, levelId, {
+          return prog.addFeature(featureType, levelId, featureSetId, {
             _type: "item",
             id: featureItem._id,
             item: featureItem,
@@ -117,23 +121,25 @@ export class FoundryProgressionRepository implements ProgressionRepository {
   async removeFeatureOf(
     classId: string,
     levelId: string,
+    featureSetId: string,
     itemId: string
   ): Promise<ClassProgression<IdRef>[]> {
     const progs = await this.readProgression();
     return this.writeProgression(
-      progs.map((prog) => prog.removeFeature(levelId, itemId))
+      progs.map((prog) => prog.removeFeature(levelId, featureSetId, itemId))
     );
   }
 
   async findFeatureOf(
     classId: string,
     levelId: string,
+    featureSetId: string,
     featureId: string
   ): Promise<ItemRef | null> {
     const progs = await this.readProgression();
     return progs
       .find((prog) => prog.class.id === classId)
-      ?.findFeature(levelId, featureId);
+      ?.findFeature(levelId, featureSetId, featureId);
   }
 
   async addClass(classItem: Item): Promise<ClassProgression<IdRef>[]> {
@@ -184,12 +190,8 @@ export class FoundryProgressionRepository implements ProgressionRepository {
       progs.progs.map((p) => {
         //foundry stores plain JSON in settings, and therefore
         const lvls = p.levels.map((l) => {
-          const [granted, options, prereq] = [
-            l.features.granted,
-            l.features.options,
-            l.features.prerequisites,
-          ];
-          const features = new LevelFeatures(granted, options, prereq);
+          const featureSets = l.features.featureSets
+          const features = new LevelFeatures(featureSets);
           return new ClassLevel(l.id, l.level, features);
         });
         return new ClassProgression(p.cls, lvls).derefProgression(

--- a/templates/features.html
+++ b/templates/features.html
@@ -6,6 +6,7 @@
       class="feature-link"
       data-class-id="{{../classId}}"
       data-item-id="{{feature.item._id}}"
+      data-feature-set-id="{{../featureSetId}}"
       data-level-id="{{../levelId}}"
     >
       <img class="feature-image" src="{{feature.item.img}}" />
@@ -15,6 +16,7 @@
       class="feature-delete"
       data-class-id="{{../classId}}"
       data-item-id="{{feature.item._id}}"
+      data-feature-set-id="{{../featureSetId}}"
       data-level-id="{{../levelId}}"
       ><i class="fas fa-trash"></i
     ></a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,35 +15,44 @@
     <div class="tab" data-tab="{{prog.cls.item._id}}" data-group="primary-tabs">
       {{#each prog.levels as | level |}}
       <h2 class="level-number">Level {{level.level}}</h2>
-      <div
-        class="features granted drop-box"
-        data-class-id="{{prog.cls.item._id}}"
-        data-level-id="{{level.id}}"
-      >
-        <h3 class="features-header">Granted</h3>
-        {{> "modules/charactermancer/templates/features.html"
-        classId=prog.cls.id levelId=level.id
-        features=level.features.granted.items}}
-      </div>
-      <div
-        class="features options drop-box"
-        data-class-id="{{prog.cls.item._id}}"
-        data-level-id="{{level.id}}"
-      >
-        <h3 class="features-header">Options</h3>
-        {{> "modules/charactermancer/templates/features.html"
-        classId=prog.cls.id levelId=level.id
-        features=level.features.options.items}}
-      </div>
-      <div
-        class="features prerequisites drop-box"
-        data-class-id="{{prog.cls.item._id}}"
-        data-level-id="{{level.id}}"
-      >
-        <h3 class="features-header">Prerequisites</h3>
-        {{> "modules/charactermancer/templates/features.html"
-        classId=prog.cls.id levelId=level.id
-        features=level.features.prerequisites.items}}
+      <div class="feature-sets">
+        {{#each level.features.featureSets as | featureSet |}}
+        <div class="feature-set">
+          <div
+            class="features granted drop-box"
+            data-class-id="{{prog.cls.item._id}}"
+            data-level-id="{{level.id}}"
+            data-feature-set-id="{{@key}}"
+          >
+            <h3 class="features-header">Granted</h3>
+            {{> "modules/charactermancer/templates/features.html"
+            classId=prog.cls.id levelId=level.id featureSetId=@key
+            features=featureSet.granted}}
+          </div>
+          <div
+            class="features options drop-box"
+            data-class-id="{{prog.cls.item._id}}"
+            data-level-id="{{level.id}}"
+            data-feature-set-id="{{@key}}"
+          >
+            <h3 class="features-header">Options</h3>
+            {{> "modules/charactermancer/templates/features.html"
+            classId=prog.cls.id levelId=level.id featureSetId=@key
+            features=featureSet.options}}
+          </div>
+          <div
+            class="features prerequisites drop-box"
+            data-class-id="{{prog.cls.item._id}}"
+            data-level-id="{{level.id}}"
+            data-feature-set-id="{{@key}}"
+          >
+            <h3 class="features-header">Prerequisites</h3>
+            {{> "modules/charactermancer/templates/features.html"
+            classId=prog.cls.id levelId=level.id featureSetId=@key
+            features=featureSet.prerequisites}}
+          </div>
+        </div>
+        {{/each}}
       </div>
       {{/each}}
       <button class="new-lvl" data-class-id="{{this.cls.item._id}}">


### PR DESCRIPTION
Instead of having a single block of `{options, granted, prereqs}`, define the level features as multiple sets `{[key: string]: {options, granted, prereqs}}`.

It allows to define multiple feature blocks per the set of prerequisites.